### PR TITLE
Pull Request to add outbound SMS notifications to Broadcast

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -226,6 +226,26 @@ It is based on the assumption that the user associated with the access token has
   end
 ```
 
+### SMS
+
+Broadcast::Medium::SMS is based on the SMSified gem.
+You must create an account on http://smsified.com before sending SMS text messages (developer accounts are free).
+You will be given a phone number to use as your very own FROM sms number. This number, along with your username and password, 
+must be added to your config during setup.  The To address is the address of the mobile number that you would like to send the SMS message to.
+
+#### Example setup
+
+```ruby
+  Broadcast.setup do |config|
+    config.Sms { |sms|
+      sms.username       = 'myaccount'
+      sms.password       = 'mypass'
+      sms.from		     = '16025551212'
+      sms.to		     = '14801234567'
+    }
+  end
+```
+
 Copyright
 ---------
 

--- a/lib/broadcast/media/sms.rb
+++ b/lib/broadcast/media/sms.rb
@@ -1,0 +1,16 @@
+require 'smsified'
+
+class Broadcast::Medium::Sms < Broadcast::Medium::Oauth
+
+ def publish(message)
+   
+   oneapi = Smsified::OneAPI.new :username => options.username,
+                                    :password => options.password
+
+   oneapi.send_sms :address => options.to,
+                      :message => message.body,
+                      :sender_address => options.from
+   
+ end
+
+end


### PR DESCRIPTION
Added SMS medium using the SMSified gem to allow Broadcast users to send SMS messages to any US mobile device.  

Developers must create an account on http://smsified.com before sending SMS text messages (Developer accounts are _free_). You will be given a phone number to use as your very own FROM sms number. This number, along with your username and password, must be added to your config during setup.  The To address is the address of the mobile number that you would like to send the SMS message to.
#### Example setup

``` ruby
  Broadcast.setup do |config|
    config.Sms { |sms|
      sms.username       = 'myaccount'
      sms.password       = 'mypass'
      sms.from           = '16025551212'
      sms.to             = '14801234567'
    }
  end
```
