### PR TITLE
Post the message body instead of self

### DIFF
--- a/lib/broadcast/media/irc.rb
+++ b/lib/broadcast/media/irc.rb
@@ -7,6 +7,6 @@ class Broadcast::Medium::Irc < Broadcast::Medium
     uri += "@#{options.server}:#{options.port ? options.port : '6667'}"
     uri += "/##{options.channel.to_s.gsub("#","") }"
 
-    ShoutBot.shout(uri) { |room| room.say message }
+    ShoutBot.shout(uri) { |room| room.say message.body }
   end
 end


### PR DESCRIPTION
When you extend a class with Broadcast::Publishable, the ShoutBot posts
the class instead of the class body.
